### PR TITLE
Fixed compilation error on macOS

### DIFF
--- a/UniCAVE2019/Assets/UniCAVE/Scripts/UniCAVE-Core/Rendering/PhysicalDisplay.cs
+++ b/UniCAVE2019/Assets/UniCAVE/Scripts/UniCAVE-Core/Rendering/PhysicalDisplay.cs
@@ -574,8 +574,12 @@ namespace UniCAVE
         /// </summary>
         void Update()
         {
-            if(!updatedViewports && WindowsUtils.CompletedOperation())
+            if(!updatedViewports)
             {
+#if UNITY_STANDALONE_WIN
+                if(!WindowsUtils.CompletedOperation())
+                    return;
+#endif
                 //we must also defer setting the camera viewports until the screen has the correct resolution
                 if(dualPipe && !dualInstance)
                 {


### PR DESCRIPTION
`WindowsUtils.CompletedOperation()` is not available on macOS.